### PR TITLE
Remove unused `io.flutter.plugin.common.PluginRegistry.Registrar` import

### DIFF
--- a/android/src/main/java/co/eivo/brother_printer/BrotherPrinterPlugin.java
+++ b/android/src/main/java/co/eivo/brother_printer/BrotherPrinterPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 


### PR DESCRIPTION
Flutter has flagged a move away from it's prior `PluginRegistry.Registrar` system as outlined in [this post](https://docs.flutter.dev/release/breaking-changes/plugin-api-migration). 

From what I can see, the `flutter_brother_printer` plugin has already implemented the outlined changes to use the new Android plugins API. However `BrotherPrinterPlugin.java` still has an unused import to `io.flutter.plugin.common.PluginRegistry.Registrar`. 

In previous flutter releases this been benign however it appears that the `Registrar` symbol has been removed completed in Flutter `3.29` causing Android builds to fail as the are unable to find the import. 

This PR removes this unused import. 